### PR TITLE
Bail out of version script when there's no changes to commit.

### DIFF
--- a/.changeset/thick-rice-battle.md
+++ b/.changeset/thick-rice-battle.md
@@ -1,0 +1,5 @@
+---
+"@jaybeeuu/scripts": minor
+---
+
+Bail out of version script when there's no changes to commit.


### PR DESCRIPTION
Allows the SDLC script a graceful exit when there's not changes to commit.