### PR TITLE
Update Jest to v30 and package version bumps

### DIFF
--- a/.changeset/slug-validation-and-typescript-fixes.md
+++ b/.changeset/slug-validation-and-typescript-fixes.md
@@ -1,0 +1,12 @@
+---
+"@jaybeeuu/compost": patch
+"@jaybeeuu/site": patch
+---
+
+Add comprehensive slug validation tests and fix TypeScript build issues
+
+- Add unit tests for validateSlug function with proper regex anchoring
+- Fix slug validation regex to exclude invalid characters between Z and a
+- Resolve TypeScript errors in preact-router Link components with proper type declarations
+- Add Cloudflare \_headers file for correct feed content types
+- Fix CircleCI config typo and update dependencies

--- a/.changeset/slug-validation-and-typescript-fixes.md
+++ b/.changeset/slug-validation-and-typescript-fixes.md
@@ -1,6 +1,20 @@
 ---
-"@jaybeeuu/compost": patch
+"@jaybe# Dependency Updates and TypeScript Fixes
+
+- Add unit tests for validateSlug function with proper regex anchoring
+- Fix slug validation regex to exclude invalid characters between Z and a
+- Resolve TypeScript errors in preact-router Link components with proper type declarations
+- Add Cloudflare _headers file for correct feed content types
+- Fix CircleCI config typo and update dependencies
+- Update Jest and related testing packages to v30
+- Update other dependencies to their latest compatible versionspost": patch
+"@jaybeeuu/conv": patch
+"@jaybeeuu/is": patch
+"@jaybeeuu/preact-async": patch
+"@jaybeeuu/preact-recoilless": patch
+"@jaybeeuu/recoilless": patch
 "@jaybeeuu/site": patch
+"@jaybeeuu/utilities": patch
 ---
 
 Add comprehensive slug validation tests and fix TypeScript build issues


### PR DESCRIPTION
Updates the changeset to include version bumps for packages affected by Jest v30 update and other dependency changes.